### PR TITLE
✨ Improved config file parsing to trim comments at end of lines

### DIFF
--- a/create_backup.sh
+++ b/create_backup.sh
@@ -211,6 +211,9 @@ parse_config_file() {
       key=$(echo "$key" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
       value=$(echo "$value" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
 
+      # Remove inline comments (everything from # to end of line)
+      value=$(echo "$value" | sed 's/[[:space:]]*#.*$//')
+
       # Remove quotes if present
       value=$(echo "$value" | sed 's/^["'\'']\(.*\)["'\'']$/\1/')
 


### PR DESCRIPTION
the rule checks for comments at the end of line. A `#` is detected as a comment only if it has spaces before it (protection in case a `#` needs to be used in a value)